### PR TITLE
Gradle projects names are fixed in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,8 +3,8 @@ rootProject.name = "jfix-stdlib"
 for (project in listOf(
         "jfix-stdlib-concurrency",
         "jfix-stdlib-files",
-        "jfix-stdlib-id_generator",
-        "jfix-stdlib-id_generator_jmh",
+        "jfix-stdlib-id-generator",
+        "jfix-stdlib-id-generator-jmh",
         "jfix-stdlib-ratelimiter",
         "jfix-stdlib-socket")) {
     include(project)


### PR DESCRIPTION
names of modules in settings.gradle.kts are fixed according to those modules' folders
![image](https://user-images.githubusercontent.com/9992425/77310270-1b68a000-6d0f-11ea-999f-2ccc1a0beb97.png)
