### PR TITLE
Unconditional error messaging fixed

### DIFF
--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -277,9 +277,11 @@ public class PendingFutureLimiter {
         Predicate<Map.Entry<CompletableFuture, Long>> isTimeoutPredicate =
                 entry -> System.currentTimeMillis() - entry.getValue() > maxFutureExecuteTime;
 
-        log.error(errorMessage);
-
         pendingCompletableFutures.entrySet().stream().filter(isTimeoutPredicate).forEach(completeExceptionally);
+
+        if (pendingCompletableFutures.entrySet().stream().anyMatch(isTimeoutPredicate)) {
+            log.error(errorMessage);
+        }
     }
 
     public interface ThresholdListener {


### PR DESCRIPTION
The bug with error messaging on queue limit reached, but futures are not timeouted is fixed.