### PR TITLE
Feature/jdk8 compatibility

### DIFF
--- a/jfix-stdlib-concurrency/build.gradle.kts
+++ b/jfix-stdlib-concurrency/build.gradle.kts
@@ -25,4 +25,9 @@ dependencies {
 
 }
 
-
+tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+        targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    }
+}


### PR DESCRIPTION
Make jfix-stdlib-concurrency compatible with jdk8. Will build on jdk11 with target bytecode 52 version (java 8 bytecode)