### PR TITLE
jdk8 compartible version of jfix-stdlib-concurrency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,8 +181,13 @@ subprojects {
     }
 
     tasks {
+        withType<JavaCompile> {
+            sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+            targetCompatibility = JavaVersion.VERSION_1_8.toString()
+        }
+
         withType<KotlinCompile> {
-            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
         withType<Test> {
             useJUnitPlatform()


### PR DESCRIPTION
Make jfix-stdlib-concurrency compatible with jdk8. Will build on jdk11 with target bytecode 52 version (java 8 bytecode)