### PR TITLE
issue-51 fix excess waiting in PendingFutureLimiter#waitAll(timeout) method

### DIFF
--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -235,7 +235,6 @@ public class PendingFutureLimiter {
                     return false;
                 }
                 if (counter.get() > 0) {
-                    counter.wait(pendingQueueSizeChangeCheckInteval);
                     long timeToWait = Math.min(pendingQueueSizeChangeCheckInteval, timeoutMillis - (System.currentTimeMillis() - start));
                     if (timeToWait > 0) {
                         counter.wait(timeToWait);


### PR DESCRIPTION
See #51
this bug does not affect anything except the time during which the waitAll(timeout) function is executed. It always takes given timeout, despite the completion of all futures. The exception is enqueued already completed single future: sometimes it managed to decrement the counter before waitAll method check it.

![](https://user-images.githubusercontent.com/28933068/82209994-eb0c3f00-9916-11ea-9c42-b7ca27b002de.png)

![](https://user-images.githubusercontent.com/28933068/82210003-ed6e9900-9916-11ea-8bd3-3c2eeeb64e84.png)
