### PR TITLE
target and source compatibility java version = 1.8 in `reference` module

### DIFF
--- a/jfix-stdlib-reference/build.gradle.kts
+++ b/jfix-stdlib-reference/build.gradle.kts
@@ -3,6 +3,11 @@ plugins {
     kotlin("jvm")
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
 
     // Should depend only on loggin api and JVM


### PR DESCRIPTION
See https://github.com/ru-fix/jfix-stdlib/issues/57