### PR TITLE
downgrade whole project to java-8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,8 +181,13 @@ subprojects {
     }
 
     tasks {
+        withType<JavaCompile> {
+            sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+            targetCompatibility = JavaVersion.VERSION_1_8.toString()
+        }
+
         withType<KotlinCompile> {
-            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
         withType<Test> {
             useJUnitPlatform()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,7 +9,7 @@ object Vers {
 
     const val resilience4j = "0.13.0"
     const val aggregating_profiler = "1.5.16"
-    const val dynamic_property = "2.0.2"
+    const val dynamic_property = "2.0.4"
 
     const val jmh = "1.21"
 

--- a/jfix-stdlib-reference/build.gradle.kts
+++ b/jfix-stdlib-reference/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
     kotlin("jvm")
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
 
     // Should depend only on loggin api and JVM


### PR DESCRIPTION
See https://github.com/ru-fix/jfix-stdlib/issues/57

Note that gradle still runs on jdk11, so we cant use dokka (build.gradle.kts:89)