### PR TITLE
fixed enqueueBlocking behaviour when maxFutureExecuteTime is 0

### DIFF
--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -210,14 +210,13 @@ public class PendingFutureLimiter {
     }
 
     private void awaitOpportunityToEnqueueAndPurge() throws InterruptedException {
-        while (counter.get() >= maxPendingCount && maxFutureExecuteTime > 0) {
+        while (counter.get() >= maxPendingCount) {
             synchronized (counter) {
-                if (counter.get() >= maxPendingCount && maxFutureExecuteTime > 0)
+                if (counter.get() >= maxPendingCount)
                     counter.wait(pendingQueueSizeChangeCheckInterval);
             }
             releaseTimeoutedIfPossible();
         }
-
     }
 
     public long getPendingCount() {

--- a/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
+++ b/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
@@ -300,6 +300,8 @@ public class PendingFutureLimiterTest {
         assertFalse(overflowedEnqueuePassed.get());
         Thread.sleep(TimeUnit.SECONDS.toMillis(10));
         assertFalse(overflowedEnqueuePassed.get());
+        unleashLatchAndCompleteAllTask();
+        await().atMost(10, TimeUnit.SECONDS).untilTrue(overflowedEnqueuePassed);
     }
 
     private Runnable notTooLongRunningTask(long duration) {

--- a/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
+++ b/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
@@ -280,6 +281,26 @@ public class PendingFutureLimiterTest {
         limiter.enqueueBlocking(CompletableFuture.runAsync(notTooLongRunningTask(taskDurationMs)));
         long largeTimeout = TimeUnit.MINUTES.toMillis(5);
         assertTimeoutPreemptively(assertingTaskTimeout, () -> limiter.waitAll(largeTimeout));
+    }
+
+    @Test
+    public void enqueueBlocking_blocks_invoking_thread_when_limit_is_reached() throws Exception {
+        PendingFutureLimiter limiter = new LimiterBuilder()
+                .executionTimeLimit(0)
+                .enqueueTasks(3)
+                .build();
+        AtomicBoolean ai = new AtomicBoolean(false);
+        // We'll try to enqueue after futures timeout is exceeded
+        Executors.newSingleThreadScheduledExecutor().execute(() -> {
+            try {
+                limiter.enqueueBlocking(createTask());
+                ai.set(true);
+            } catch (InterruptedException ignore) {
+            }
+        });
+        assertFalse(ai.get());
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+        assertFalse(ai.get());
     }
 
     private Runnable notTooLongRunningTask(long duration) {


### PR DESCRIPTION
When maxFutureExecuteTime is set to 0 enqueueBlocking(...) used to release thread instead of blocking it, when limit is reached.