### PR TITLE
Pending future limiter parametered future immutability

### DIFF
--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -191,6 +191,8 @@ public class PendingFutureLimiter {
             }
         });
 
+        long queueSize = counter.incrementAndGet();
+
         resultFuture.handleAsync((any, exc) -> {
             long value = counter.decrementAndGet();
             pendingFutures.remove(resultFuture);
@@ -206,7 +208,6 @@ public class PendingFutureLimiter {
             return null;
         });
         pendingFutures.put(resultFuture, System.currentTimeMillis());
-        long queueSize = counter.incrementAndGet();
 
         if (queueSize == maxPendingCount && thresholdListener != null) {
             thresholdListener.onHiLimitReached();

--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -90,12 +90,6 @@ public class PendingFutureLimiter {
      */
     public PendingFutureLimiter setMaxPendingCount(int maxPendingCount) {
 
-        int threshold = calculateThreshold(maxPendingCount, thresholdFactor);
-
-        if (threshold <= 0 || threshold >= maxPendingCount) {
-            throw new IllegalArgumentException("Invalid thresholdFactor");
-        }
-
         this.maxPendingCount = maxPendingCount;
 
         synchronized (counter) {
@@ -133,7 +127,7 @@ public class PendingFutureLimiter {
 
         int threshold = calculateThreshold(maxPendingCount, thresholdFactor);
 
-        if (threshold <= 0 || threshold >= maxPendingCount) {
+        if (threshold < 0 || threshold > maxPendingCount) {
             throw new IllegalArgumentException("Invalid thresholdFactor");
         }
 

--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -90,12 +90,6 @@ public class PendingFutureLimiter {
      */
     public PendingFutureLimiter setMaxPendingCount(int maxPendingCount) {
 
-        int threshold = calculateThreshold(maxPendingCount, thresholdFactor);
-
-        if (threshold < 0 || threshold > maxPendingCount) {
-            throw new IllegalArgumentException("Invalid thresholdFactor");
-        }
-
         this.maxPendingCount = maxPendingCount;
 
         synchronized (counter) {
@@ -125,15 +119,18 @@ public class PendingFutureLimiter {
      * I. e., to get a threshold 800 with maxPendingCount 1000,
      * you should set thresholdFactor = 0.2
      *
-     * @param thresholdFactor % of free slots from maxPendingCount,
+     * @param thresholdFactor split of free slots from maxPendingCount,
      *                        when it is reached the signal about critical workload will be sent
      *                        to {@link ThresholdListener#onLowLimitSubceed()}
+     * @throws IllegalArgumentException when thresholdFactor is less than 0 or more than 1
      */
     public PendingFutureLimiter changeThresholdFactor(float thresholdFactor) {
 
-        int threshold = calculateThreshold(maxPendingCount, thresholdFactor);
+        if (Math.signum(thresholdFactor) < 0) {
+            throw new IllegalArgumentException("Invalid thresholdFactor");
+        }
 
-        if (threshold < 0 || threshold > maxPendingCount) {
+        if (Float.compare(thresholdFactor, 1f) > 0) {
             throw new IllegalArgumentException("Invalid thresholdFactor");
         }
 

--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -197,10 +197,11 @@ public class PendingFutureLimiter {
             long value = counter.decrementAndGet();
             pendingFutures.remove(resultFuture);
 
+            if (value == getThreshold() && thresholdListener != null) {
+                thresholdListener.onLowLimitSubceed();
+            }
+
             if (value == 0 || value == getThreshold()) {
-                if (value == getThreshold() && thresholdListener != null) {
-                    thresholdListener.onLowLimitSubceed();
-                }
                 synchronized (counter) {
                     counter.notifyAll();
                 }

--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -178,12 +178,6 @@ public class PendingFutureLimiter {
      */
     protected <T> CompletableFuture<T> internalEnqueue(CompletableFuture<T> future,
                                                        boolean needToBlock) throws InterruptedException {
-        long queueSize = counter.incrementAndGet();
-
-        if (queueSize == maxPendingCount && thresholdListener != null) {
-            thresholdListener.onHiLimitReached();
-        }
-
         if (needToBlock) {
             awaitOpportunityToEnqueueAndPurge();
         }
@@ -212,6 +206,12 @@ public class PendingFutureLimiter {
             return null;
         });
         pendingFutures.put(resultFuture, System.currentTimeMillis());
+        long queueSize = counter.incrementAndGet();
+
+        if (queueSize == maxPendingCount && thresholdListener != null) {
+            thresholdListener.onHiLimitReached();
+        }
+
         return resultFuture;
     }
 

--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -90,6 +90,12 @@ public class PendingFutureLimiter {
      */
     public PendingFutureLimiter setMaxPendingCount(int maxPendingCount) {
 
+        int threshold = calculateThreshold(maxPendingCount, thresholdFactor);
+
+        if (threshold < 0 || threshold > maxPendingCount) {
+            throw new IllegalArgumentException("Invalid thresholdFactor");
+        }
+
         this.maxPendingCount = maxPendingCount;
 
         synchronized (counter) {

--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiter.java
@@ -192,6 +192,7 @@ public class PendingFutureLimiter {
         });
 
         long queueSize = counter.incrementAndGet();
+        pendingFutures.put(resultFuture, System.currentTimeMillis());
 
         resultFuture.handleAsync((any, exc) -> {
             long value = counter.decrementAndGet();
@@ -208,7 +209,6 @@ public class PendingFutureLimiter {
             }
             return null;
         });
-        pendingFutures.put(resultFuture, System.currentTimeMillis());
 
         if (queueSize == maxPendingCount && thresholdListener != null) {
             thresholdListener.onHiLimitReached();

--- a/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
+++ b/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
@@ -42,13 +42,12 @@ public class PendingFutureLimiterTest {
         limiter.changeThresholdFactor(0f);
         limiter.changeThresholdFactor(1f);
         limiter.changeThresholdFactor(0.5f);
+        limiter.changeThresholdFactor(-0.0f);
+
         assertThrows(IllegalArgumentException.class, () -> limiter.changeThresholdFactor(-1f));
-
-        limiter.changeThresholdFactor(-0.1f);
-        assertThrows(IllegalArgumentException.class, () -> limiter.setMaxPendingCount(10));
-
-        limiter.changeThresholdFactor(1.1f);
-        assertThrows(IllegalArgumentException.class, () -> limiter.setMaxPendingCount(10));
+        assertThrows(IllegalArgumentException.class, () -> limiter.changeThresholdFactor(-0.1f));
+        assertThrows(IllegalArgumentException.class, () -> limiter.changeThresholdFactor(1.1f));
+        assertThrows(IllegalArgumentException.class, () -> limiter.changeThresholdFactor(1.0000001f));
     }
 
     @Test

--- a/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
+++ b/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
@@ -10,10 +10,8 @@ import java.time.Duration;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
 
 import static org.awaitility.Awaitility.await;
-import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -489,18 +487,6 @@ public class PendingFutureLimiterTest {
             return this;
         }
 
-    }
-
-    public static class SessionStub {
-        private volatile boolean readable = true;
-
-        public boolean isReadable() {
-            return this.readable;
-        }
-
-        public void setReadable(boolean readable) {
-            this.readable = readable;
-        }
     }
 
     private void unleashLatchAndCompleteAllTask() {

--- a/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
+++ b/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
@@ -319,17 +319,17 @@ public class PendingFutureLimiterTest {
         CompletableFuture<String> normalResult = limiter.enqueueBlocking(source);
 
         assertFalse(source == normalResult);
-        source.complete("1");
-        assertEquals(normalResult.get(), "1");
+        String message = "OK";
+        source.complete(message);
+        assertEquals(normalResult.get(), message);
 
         source = new CompletableFuture<>();
         CompletableFuture<String> failedResult = limiter.enqueueBlocking(source);
 
-        Exception thrown = new Exception("I am failed");
+        Exception thrown = new Exception("I have failed");
         source.completeExceptionally(thrown);
         ExecutionException wrapped = assertThrows(ExecutionException.class, () -> failedResult.get());
         assertEquals(wrapped.getCause(), thrown);
-
     }
 
     @Test

--- a/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
+++ b/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
@@ -37,6 +37,21 @@ public class PendingFutureLimiterTest {
     }
 
     @Test
+    public void threshold_change_border_values_test() throws Exception {
+        PendingFutureLimiter limiter = new LimiterBuilder().maxPendingCount(3).build();
+        limiter.changeThresholdFactor(0f);
+        limiter.changeThresholdFactor(1f);
+        limiter.changeThresholdFactor(0.5f);
+        assertThrows(IllegalArgumentException.class, () -> limiter.changeThresholdFactor(-1f));
+
+        limiter.changeThresholdFactor(-0.1f);
+        assertThrows(IllegalArgumentException.class, () -> limiter.setMaxPendingCount(10));
+
+        limiter.changeThresholdFactor(1.1f);
+        assertThrows(IllegalArgumentException.class, () -> limiter.setMaxPendingCount(10));
+    }
+
+    @Test
     public void block_on_task_when_pending_count_bigger_than_max_border() throws Exception {
 
         PendingFutureLimiter limiter = new LimiterBuilder()

--- a/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
+++ b/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
@@ -274,6 +274,8 @@ public class PendingFutureLimiterTest {
                 .maxPendingCount(10)
                 .build();
 
+        limiter.changeThresholdFactor(0.3f);
+
         AtomicInteger lowLimitCallCounter = new AtomicInteger(0);
         limiter.setThresholdListener(new PendingFutureLimiter.ThresholdListener() {
             @Override

--- a/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
+++ b/jfix-stdlib-concurrency/src/test/java/ru/fix/stdlib/concurrency/futures/PendingFutureLimiterTest.java
@@ -232,7 +232,7 @@ public class PendingFutureLimiterTest {
         assertEquals(limiter.getPendingCount(), 9);
         assertEquals(thresholdCallCounter.get(), 0);
 
-        CompletableFuture localLatch = new CompletableFuture();
+        CompletableFuture<String> localLatch = new CompletableFuture<>();
 
         limiter.enqueueUnlimited(localLatch.thenApplyAsync((s) -> s));
 
@@ -250,7 +250,7 @@ public class PendingFutureLimiterTest {
 
         await().atMost(1, TimeUnit.SECONDS).until(() -> limiter.getPendingCount() == 9);
 
-        CompletableFuture parallelEnqueueLatch = new CompletableFuture();
+        CompletableFuture<String> parallelEnqueueLatch = new CompletableFuture<>();
 
         for (int i = 0; i < 50; i++) {
             parallelEnqueueLatch.thenApplyAsync((s) -> {
@@ -289,7 +289,7 @@ public class PendingFutureLimiterTest {
             limiter.enqueueUnlimited(createTask());
         }
 
-        CompletableFuture singleFuture = new CompletableFuture();
+        CompletableFuture<String> singleFuture = new CompletableFuture<>();
         limiter.enqueueUnlimited(singleFuture);
 
         assertEquals(limiter.getPendingCount(), 8);
@@ -299,7 +299,7 @@ public class PendingFutureLimiterTest {
         await().atMost(1, TimeUnit.SECONDS).until(() -> lowLimitCallCounter.get() == 1);
 
 
-        CompletableFuture localLatch = new CompletableFuture();
+        CompletableFuture<String> localLatch = new CompletableFuture<>();
 
         for (int i = 0; i < 20; i++) {
             limiter.enqueueUnlimited(localLatch.thenApplyAsync((s) -> s));
@@ -358,7 +358,7 @@ public class PendingFutureLimiterTest {
                 .maxPendingCount(4)
                 .enqueueTasks(3)
                 .build();
-        CompletableFuture localLatch = new CompletableFuture();
+        CompletableFuture<String> localLatch = new CompletableFuture<>();
         limiter.enqueueBlocking(localLatch);
 
         AtomicBoolean overflowedEnqueuePassed = new AtomicBoolean(false);
@@ -388,7 +388,7 @@ public class PendingFutureLimiterTest {
         CompletableFuture<String> source = new CompletableFuture<>();
         CompletableFuture<String> result = limiter.enqueueBlocking(source);
 
-        assertFalse(source == result);
+        assertNotSame(source, result);
         String message = "OK";
         source.complete(message);
         assertEquals(result.get(), message);
@@ -405,7 +405,7 @@ public class PendingFutureLimiterTest {
 
         Exception thrown = new Exception("I have failed");
         source.completeExceptionally(thrown);
-        ExecutionException wrapped = assertThrows(ExecutionException.class, () -> result.get());
+        ExecutionException wrapped = assertThrows(ExecutionException.class, result::get);
         assertEquals(wrapped.getCause(), thrown);
     }
 
@@ -422,7 +422,7 @@ public class PendingFutureLimiterTest {
         CompletableFuture<String> result = limiter.enqueueBlocking(source);
 
         limiter.enqueueBlocking(new CompletableFuture<>());
-        ExecutionException wrapped = assertThrows(ExecutionException.class, () -> result.get());
+        ExecutionException wrapped = assertThrows(ExecutionException.class, result::get);
         assertTrue(wrapped.getCause() instanceof TimeoutException);
 
         CompletableFuture<String> onSource = source.thenApplyAsync(message -> message + "!");


### PR DESCRIPTION
The future, provided as a parameter to enqueue in PendingFutureLimiter shouldn't be muted anyhow inside it. I. e., even when future is timeouted, the pipeline holding it shouldn't be broken.