### PR TITLE
Feature/simplify reducing accumulator

### DIFF
--- a/jfix-stdlib-concurrency/build.gradle.kts
+++ b/jfix-stdlib-concurrency/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(Libs.kotlin_reflect)
 
     testImplementation(Libs.hamkrest)
+    testImplementation(Libs.kotest_assertions)
     testImplementation(Libs.awaitility)
     testImplementation(Libs.junit_api)
     testImplementation(Libs.junit_params)

--- a/jfix-stdlib-concurrency/src/main/kotlin/ru/fix/stdlib/concurrency/events/ReducingEventAccumulator.kt
+++ b/jfix-stdlib-concurrency/src/main/kotlin/ru/fix/stdlib/concurrency/events/ReducingEventAccumulator.kt
@@ -4,8 +4,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
-private const val DEFAULT_EXTRACT_TIMEOUT_MS = 1_000L
-
 /**
  * All events passed through [publishEvent] will be merged by [reduceFunction] into single accumulator.
  * When [extractAccumulatedValue] invoked, it will extract value from accumulator.
@@ -123,7 +121,7 @@ class ReducingEventAccumulator<ReceivingEventT, AccumulatorT>(
     }
 
     /**
-     * @return true if [close] was invoked
+     * @return true if accumulator is closed
      * */
     fun isClosed() = lock.withLock {
         return@withLock closed
@@ -139,7 +137,7 @@ class ReducingEventAccumulator<ReceivingEventT, AccumulatorT>(
 
     companion object {
         @JvmStatic
-        fun <EventT> lastEventWinAccumulator() =
+        fun <EventT> createLastEventWinAccumulator() =
                 ReducingEventAccumulator { _: EventT?, event: EventT -> event }
     }
 }

--- a/jfix-stdlib-concurrency/src/main/kotlin/ru/fix/stdlib/concurrency/events/ReducingEventAccumulator.kt
+++ b/jfix-stdlib-concurrency/src/main/kotlin/ru/fix/stdlib/concurrency/events/ReducingEventAccumulator.kt
@@ -21,7 +21,7 @@ import kotlin.concurrent.withLock
  *   })
  * val consumer = Executors.newSingleThreadExecutor()
  * consumer.execute {
- *   while(!accumulator.isClosed()) {
+ *   while(!accumulator.isClosedAndEmpty()) {
  *     Thread.sleep(100) //simulate slow event consuming
  *     println(it.size) //print received list size
  *   }

--- a/jfix-stdlib-concurrency/src/test/kotlin/ru/fix/stdlib/concurrency/events/ReducingEventAccumulatorTest.kt
+++ b/jfix-stdlib-concurrency/src/test/kotlin/ru/fix/stdlib/concurrency/events/ReducingEventAccumulatorTest.kt
@@ -15,10 +15,10 @@ internal class ReducingEventAccumulatorTest {
     @Test
     fun `WHEN publish single time THEN handler invoked one time`() {
         val accumulator = ReducingEventAccumulator.createLastEventWinAccumulator<Any>()
-        assertNull(accumulator.extractAccumulatedValue())
+        assertNull(accumulator.extractAccumulatedValue(1000))
         accumulator.publishEvent(Any())
         assertNotNull(accumulator.extractAccumulatedValue())
-        assertNull(accumulator.extractAccumulatedValue())
+        assertNull(accumulator.extractAccumulatedValue(1000))
     }
 
     @Test
@@ -43,8 +43,8 @@ internal class ReducingEventAccumulatorTest {
         }
         awaitThreadsAfterPublishingLatch.await()
 
-        val firstAccumulatedValue = sumAccumulator.extractAccumulatedValue()!!
-        val secondAccumulatedValue = sumAccumulator.extractAccumulatedValue()
+        val firstAccumulatedValue = sumAccumulator.extractAccumulatedValue(1000)!!
+        val secondAccumulatedValue = sumAccumulator.extractAccumulatedValue(1000)
         assertEquals(events.sum(), firstAccumulatedValue + (secondAccumulatedValue ?: 0))
 
         executor.shutdown()
@@ -93,7 +93,7 @@ internal class ReducingEventAccumulatorTest {
         var nextReceivedEvents: MutableList<Int>? = mutableListOf()
         while (nextReceivedEvents != null) {
             allReceivedEvents.addAll(nextReceivedEvents)
-            nextReceivedEvents = listAccumulator.extractAccumulatedValue()
+            nextReceivedEvents = listAccumulator.extractAccumulatedValue(1000)
         }
 
         assertEquals(events.toSet(), allReceivedEvents.toSet())
@@ -154,7 +154,7 @@ internal class ReducingEventAccumulatorTest {
             val value = sumAccumulator.extractAccumulatedValue(TimeUnit.MINUTES.toMillis(1))
             extractMethodUnblocked.set(true)
         }
-        sleep(1000)
+        sleep(TimeUnit.SECONDS.toMillis(1))
         extractMethodUnblocked.get().shouldBeFalse()
 
         sumAccumulator.close()

--- a/jfix-stdlib-concurrency/src/test/kotlin/ru/fix/stdlib/concurrency/events/ReducingEventAccumulatorTest.kt
+++ b/jfix-stdlib-concurrency/src/test/kotlin/ru/fix/stdlib/concurrency/events/ReducingEventAccumulatorTest.kt
@@ -14,7 +14,7 @@ internal class ReducingEventAccumulatorTest {
 
     @Test
     fun `WHEN publish single time THEN handler invoked one time`() {
-        val accumulator = ReducingEventAccumulator.lastEventWinAccumulator<Any>()
+        val accumulator = ReducingEventAccumulator.createLastEventWinAccumulator<Any>()
         assertNull(accumulator.extractAccumulatedValue())
         accumulator.publishEvent(Any())
         assertNotNull(accumulator.extractAccumulatedValue())
@@ -112,8 +112,11 @@ internal class ReducingEventAccumulatorTest {
         sumAccumulator.publishEvent(2)
 
         var receivedEventSum = 0
-        sumAccumulator.receiveReducedEventsUntilClosedAndEmpty {
-            receivedEventSum += it
+
+        while(!sumAccumulator.isClosedAndEmpty()){
+            sumAccumulator.extractAccumulatedValue()?.let {
+                receivedEventSum += it
+            }
         }
         assertEquals(eventBeforeClosing, receivedEventSum)
     }
@@ -129,8 +132,11 @@ internal class ReducingEventAccumulatorTest {
         sumAccumulator.publishEvent(2)
 
         var receivedEventSum = 0
-        sumAccumulator.receiveReducedEventsUntilClosed {
-            receivedEventSum += it
+
+        while(!sumAccumulator.isClosed()){
+            sumAccumulator.extractAccumulatedValue()?.let {
+                receivedEventSum += it
+            }
         }
         assertEquals(0, receivedEventSum)
     }

--- a/jfix-stdlib-concurrency/src/test/resources/log4j2-test.xml
+++ b/jfix-stdlib-concurrency/src/test/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
         status="WARN">
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %logger(%F:%L)%n%highlight{%-5level} %msg%n"/>
+            <PatternLayout pattern="%highlight{%-5level} %d{dd-MM-yy HH:mm:ss.SSS} [%t] %logger(%F:%L) %n%msg%n"/>
         </Console>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
Problems:
1. When closing method is invoked consumer still have to wait for fixed timeout in the loop. This increase shutdown delay in user code. 
2. consumer loop thread wakes up regularly event if there is no new events in accumulator and wastes CPU  
3. consumeEventsUntilClosed,consumeEventsUntilClosedIsEmpty methods are simple recipes that contain single while loop. 
In user code is will be more clear to have simple while loop rather than wondering each time what that methods does. 
Methods removed.  