### PR TITLE
Executors metrics are enriched AND ProfiledScheduledThreadPoolExecutor idle threads killing fixed

### DIFF
--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/threads/ProfiledScheduledThreadPoolExecutor.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/threads/ProfiledScheduledThreadPoolExecutor.java
@@ -7,12 +7,9 @@ import ru.fix.dynamic.property.api.PropertySubscription;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ProfiledScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
-    private static final long THREAD_IDLE_TIMEOUT_BEFORE_TERMINATION_SEC = 60;
-
     final Profiler profiler;
 
     final ThreadLocal<ProfiledCall> runExecution = new ThreadLocal<>();
@@ -53,8 +50,10 @@ public class ProfiledScheduledThreadPoolExecutor extends ScheduledThreadPoolExec
         poolSizeIndicatorName = "pool." + profilerPoolName + ".poolSize";
 
         this.setRemoveOnCancelPolicy(true);
-        this.setKeepAliveTime(THREAD_IDLE_TIMEOUT_BEFORE_TERMINATION_SEC, TimeUnit.SECONDS);
-        this.allowCoreThreadTimeOut(true);
+        //Do not use KeepAliveTime, since idle threads is forbidden to kill
+        //If we kill idle threads, tasks scheduled with delay bigger that keepAliveTime
+        //will never be launched by scheduler
+        this.allowCoreThreadTimeOut(false);
 
         this.maxPoolSizeSubscription = maxPoolSize
                 .createSubscription()

--- a/jfix-stdlib-concurrency/src/test/kotlin/ru/fix/stdlib/concurrency/threads/ProfiledPoolsTest.kt
+++ b/jfix-stdlib-concurrency/src/test/kotlin/ru/fix/stdlib/concurrency/threads/ProfiledPoolsTest.kt
@@ -203,7 +203,7 @@ class ProfiledPoolsTest {
                     {
                         latch.countDown()
                         taskCompleted.increment()
-                        if (i == 100) {
+                        if (i >= 99) {
                             releasePoolLatch.await()
                         }
                     },
@@ -223,7 +223,7 @@ class ProfiledPoolsTest {
         }.let {
             println(it)
             assertEquals(0L, it.indicators[Identity("pool.test.queue")])
-            assertEquals(1L, it.indicators[Identity("pool.test.activeThreads")])
+            assertEquals(2L, it.indicators[Identity("pool.test.activeThreads")])
             assertEquals(2L, it.indicators[Identity("pool.test.poolSize")])
             assertEquals(2L, it.indicators[Identity("pool.test.maxPoolSize")])
         }

--- a/jfix-stdlib-concurrency/src/test/kotlin/ru/fix/stdlib/concurrency/threads/ProfiledPoolsTest.kt
+++ b/jfix-stdlib-concurrency/src/test/kotlin/ru/fix/stdlib/concurrency/threads/ProfiledPoolsTest.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.LongAdder
 
 class ProfiledPoolsTest {
 
-    @Test()
+    @Test
     fun `submit tasks, close pool and wait for termination`() {
 
         val profiler = AggregatingProfiler()
@@ -48,6 +48,8 @@ class ProfiledPoolsTest {
             println(it)
             assertEquals(98L, it.indicators[Identity("pool.test.queue")])
             assertEquals(2L, it.indicators[Identity("pool.test.activeThreads")])
+            assertEquals(2, it.indicators[Identity("pool.test.poolSize")])
+            assertEquals(2, it.indicators[Identity("pool.test.maxPoolSize")])
         }
 
         //release tasks
@@ -59,18 +61,19 @@ class ProfiledPoolsTest {
 
         assert.that(100, equalTo(taskCompleted.sum()))
 
-        reporter.buildReportAndReset().let {
-            println(it)
-            assertThat(100L, equalTo(it.profilerCallReports.find { it.identity.name == "pool.test.run" }?.stopSum))
-            assertThat(0L, equalTo(it.profilerCallReports.find { it.identity.name == "pool.test.run" }?.activeCallsCountMax))
-            assertThat(98L, equalTo(it.profilerCallReports.find { it.identity.name == "pool.test.await" }?.stopSum))
-            assertThat(0L, equalTo(it.profilerCallReports.find { it.identity.name == "pool.test.await" }?.activeCallsCountMax))
+        reporter.buildReportAndReset().let { report ->
+            println(report)
+            val runReport = report.profilerCallReports.find { it.identity.name == "pool.test.run" }
+            assertThat(100L, equalTo(runReport?.stopSum))
+            assertThat(0L, equalTo(runReport?.activeCallsCountMax))
+            val awaitReport = report.profilerCallReports.find { it.identity.name == "pool.test.await" }
+            assertThat(98L, equalTo(awaitReport?.stopSum))
+            assertThat(0L, equalTo(awaitReport?.activeCallsCountMax))
         }
 
     }
 
-
-    @Test()
+    @Test
     fun `common pool indicators display common pool state`() {
 
         val profiler = AggregatingProfiler()
@@ -105,7 +108,7 @@ class ProfiledPoolsTest {
 
     }
 
-    @Test()
+    @Test
     fun `single task submission`() {
         val profiler = AggregatingProfiler()
         val reporter = profiler.createReporter()
@@ -146,7 +149,7 @@ class ProfiledPoolsTest {
         assertEquals(1, taskCompleted.sum())
     }
 
-    @Test()
+    @Test
     fun `single task schedulling`() {
         val profiler = AggregatingProfiler()
         val reporter = profiler.createReporter()
@@ -181,7 +184,7 @@ class ProfiledPoolsTest {
     }
 
 
-    @Test()
+    @Test
     fun `schedule tasks, close pool and wait for termination`() {
 
         val profiler = AggregatingProfiler()
@@ -193,12 +196,16 @@ class ProfiledPoolsTest {
         val taskCompleted = LongAdder()
 
         val latch = CountDownLatch(100)
+        val releasePoolLatch = CountDownLatch(1)
 
         for (i in 1..100) {
             pool.schedule(
                     {
                         latch.countDown()
                         taskCompleted.increment()
+                        if (i == 100) {
+                            releasePoolLatch.await()
+                        }
                     },
                     1,
                     TimeUnit.MILLISECONDS)
@@ -206,14 +213,32 @@ class ProfiledPoolsTest {
 
         latch.await()
 
+        reporter.buildReportAndReset { metric, _ ->
+            metric.name in setOf(
+                    "pool.test.queue",
+                    "pool.test.activeThreads",
+                    "pool.test.poolSize",
+                    "pool.test.maxPoolSize"
+            )
+        }.let {
+            println(it)
+            assertEquals(0L, it.indicators[Identity("pool.test.queue")])
+            assertEquals(1L, it.indicators[Identity("pool.test.activeThreads")])
+            assertEquals(2L, it.indicators[Identity("pool.test.poolSize")])
+            assertEquals(2L, it.indicators[Identity("pool.test.maxPoolSize")])
+        }
+
+        releasePoolLatch.countDown()
+
         pool.shutdown()
 
         assertTrue { pool.awaitTermination(10, TimeUnit.SECONDS) }
 
-        reporter.buildReportAndReset().let {
-            println(it)
-            assertEquals(100L, it.profilerCallReports.find { it.identity.name == "pool.test.run" }?.stopSum)
-            assertEquals(0L, it.profilerCallReports.find { it.identity.name == "pool.test.run" }?.activeCallsCountMax)
+        reporter.buildReportAndReset().let { report ->
+            println(report)
+            val runReport = report.profilerCallReports.find { it.identity.name == "pool.test.run" }
+            assertEquals(100L, runReport?.stopSum)
+            assertEquals(0L, runReport?.activeCallsCountMax)
         }
 
         assertEquals(100L, taskCompleted.sum())
@@ -227,7 +252,7 @@ class ProfiledPoolsTest {
         fun newProfilerInstance(): Any {
             // loading via thread context class loader (TCCL)
             return Thread.currentThread().contextClassLoader.loadClass(NoopProfiler::class.qualifiedName)
-                .getDeclaredConstructor().newInstance()
+                    .getDeclaredConstructor().newInstance()
         }
 
         pool.submit {
@@ -259,7 +284,7 @@ class ProfiledPoolsTest {
         fun newProfilerInstance(): Any {
             // loading via thread context class loader (TCCL)
             return Thread.currentThread().contextClassLoader.loadClass(NoopProfiler::class.qualifiedName)
-                .getDeclaredConstructor().newInstance()
+                    .getDeclaredConstructor().newInstance()
         }
 
         val tccl = Thread.currentThread().contextClassLoader

--- a/jfix-stdlib-concurrency/src/test/resources/log4j2-test.xml
+++ b/jfix-stdlib-concurrency/src/test/resources/log4j2-test.xml
@@ -10,8 +10,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="ru.fix" level="info"/>
-        <Logger name="ru.fix.stdlib.concurrency.threads.ReschedulableScheduler" level="trace"/>
+        <Logger name="ru.fix" level="trace"/>
 
         <Root level="info">
             <AppenderRef ref="console"/>

--- a/jfix-stdlib-reference/src/test/resources/log4j2-test.xml
+++ b/jfix-stdlib-reference/src/test/resources/log4j2-test.xml
@@ -10,7 +10,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="ru.fix" level="info"/>
+        <Logger name="ru.fix" level="trace"/>
         <Root level="info">
             <AppenderRef ref="console"/>
         </Root>


### PR DESCRIPTION
Executors metrics are enriched with maxPoolSize indicator AND ProfiledScheduledThreadPoolExecutor idle threads killing fixed