### PR TITLE
ReschedulableScheduler.scheduleIfNotShutdown

### DIFF
--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/threads/ReschedulableScheduler.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/threads/ReschedulableScheduler.java
@@ -62,10 +62,11 @@ public class ReschedulableScheduler implements AutoCloseable {
     public Optional<ScheduledFuture<?>> scheduleIfNotShutdown(DynamicProperty<Schedule> scheduleSupplier,
                                                     DynamicProperty<Long> startDelay,
                                                     Runnable task) {
-        if (!shutdownReadLock.tryLock() || isShutdown) {
-            return Optional.empty();
-        }
+        boolean lockAcquired = shutdownReadLock.tryLock();
         try {
+            if (!lockAcquired || isShutdown) {
+                return Optional.empty();
+            }
             SelfSchedulableTaskWrapper taskWrapper = new SelfSchedulableTaskWrapper(
                     scheduleSupplier,
                     startDelay,

--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/threads/ReschedulableScheduler.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/threads/ReschedulableScheduler.java
@@ -79,7 +79,7 @@ public class ReschedulableScheduler implements AutoCloseable {
             activeTasks.add(taskWrapper);
             return Optional.of(taskWrapper.launch());
         } finally {
-            shutdownReadLock.unlock();
+            if(lockAcquired) shutdownReadLock.unlock();
         }
     }
 


### PR DESCRIPTION
`schedule` method throws unchecked exception if `shutdown` has been already executed.  Therefore client code can't use these methods concurrently:
```kotlin
@Volatile
var clientShutdownFlag = false

fun clientShutdown() {
    clientShutdownFlag = true
    reschedulableScheduler.shutdown()
}
fun foo() {
    if (!clientShutdownFlag) { // race condition!
        reschedulableScheduler.schedule() // may procude IllegalStateException
    }
}
```
client has to do some synchronization to make sure that unchecked exception won't be thrown:
```kotlin
fun clientShutdown() {
    writeLock.withLock {
        clientShutdownFlag = true
    }
    reschedulableScheduler.shutdown()
}
fun foo() = readLock.withLock {
    if (!clientShutdownFlag) {
        reschedulableScheduler.schedule()
    }
}
```
Suggestion: return special value instead of throwing unchecked exception. Then client will be able to invoke `shutdown` concurrently with `schedule`:
```kotlin
fun clientShutdown() {
    reschedulableScheduler.shutdown()
}
fun foo() {
    reschedulableScheduler.scheduleIfNotShutdown()
}
```