### PR TITLE
Enhancements for BatchingManager and its BatchProcessorsTracker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ buildscript {
         classpath(Libs.dokka_gradle_plugin)
         classpath(Libs.gradle_kotlin_stdlib)
         classpath(Libs.gradle_kotlin_jdk8)
-        classpath(Libs.jmh_gradle_plugin)
     }
 }
 
@@ -28,6 +27,7 @@ plugins {
     `maven-publish`
     id(Libs.nexus_publish_plugin) version "0.4.0" apply false
     id(Libs.nexus_staging_plugin) version "0.21.2"
+    id(Libs.jmh_gradle_plugin) version Vers.jmh_plugin apply false
 }
 
 /**
@@ -73,13 +73,12 @@ subprojects {
     }
 
     repositories {
-        jcenter()
         mavenCentral()
         mavenLocal()
     }
 
     val sourcesJar by tasks.creating(Jar::class) {
-        classifier = "sources"
+        archiveClassifier.set("sources")
         from("src/main/java")
         from("src/main/kotlin")
     }
@@ -89,7 +88,7 @@ subprojects {
     }
 
     val dokkaJar by tasks.creating(Jar::class) {
-        classifier = "javadoc"
+        archiveClassifier.set("javadoc")
 
         from(dokkaTask.outputDirectory)
         dependsOn(dokkaTask)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,7 +14,8 @@ object Vers {
 
     const val jackson = "2.11.3"
 
-    const val jmh = "1.21"
+    const val jmh = "1.36"
+    const val jmh_plugin = "0.7.0"
 
     const val log4j = "2.12.0"
 
@@ -60,7 +61,7 @@ object Libs {
     const val aggregating_profiler = "ru.fix:aggregating-profiler:${Vers.aggregating_profiler}"
     const val dynamic_property = "ru.fix:dynamic-property-api:${Vers.dynamic_property}"
 
-    const val jmh_gradle_plugin = "me.champeau.gradle:jmh-gradle-plugin:0.5.0-rc-2"
+    const val jmh_gradle_plugin = "me.champeau.jmh"
     const val jmh = "org.openjdk.jmh:jmh-core:${Vers.jmh}"
     const val jmh_generator_ann = "org.openjdk.jmh:jmh-generator-annprocess:${Vers.jmh}"
     const val jmh_generator_bytecode = "org.openjdk.jmh:jmh-generator-bytecode:${Vers.jmh}"

--- a/jfix-stdlib-batching/build.gradle.kts
+++ b/jfix-stdlib-batching/build.gradle.kts
@@ -1,6 +1,15 @@
 plugins {
     java
     kotlin("jvm")
+    id(Libs.jmh_gradle_plugin) apply true
+}
+
+jmh {
+    warmupIterations.set(2)
+    fork.set(2)
+    threads.set(1)
+    benchmarkMode.set(listOf("thrpt"))
+    duplicateClassesStrategy.set(DuplicatesStrategy.WARN)
 }
 
 dependencies {

--- a/jfix-stdlib-batching/jmh-results.txt
+++ b/jfix-stdlib-batching/jmh-results.txt
@@ -1,0 +1,3 @@
+Benchmark                                            Mode  Cnt  Score   Error  Units
+BatchingManagerHighContentionJmh.poolQueueSizeTest  thrpt   10  1,254 ± 0,343  ops/s
+BatchingManagerHighContentionJmh.semaphoreTest      thrpt   10  1,399 ± 0,275  ops/s

--- a/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchProcessorSemaphore.java
+++ b/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchProcessorSemaphore.java
@@ -1,0 +1,79 @@
+package ru.fix.stdlib.batching;
+
+import ru.fix.aggregating.profiler.Identity;
+import ru.fix.aggregating.profiler.ProfiledCall;
+import ru.fix.aggregating.profiler.Profiler;
+
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.stream.Collectors;
+
+import static ru.fix.stdlib.batching.BatchingManagerMetricsProvider.BATCHING_MANAGER_ID_TAG_NAME;
+import static ru.fix.stdlib.batching.BatchingManagerMetricsProvider.BATCHING_MANAGER_KEY_TAG_NAME;
+
+class BatchProcessorSemaphore<ConfigT, PayloadT, KeyT> implements Runnable {
+
+    private final ConfigT config;
+
+    private final Semaphore batchProcessorsTracker;
+    private final List<Operation<PayloadT>> batch;
+    private final BatchTask<ConfigT, PayloadT, KeyT> batchTask;
+    private final KeyT key;
+
+    private final Profiler profiler;
+
+    private final ProfiledCall awaitExecution;
+    private final Identity handleMetricIdentity;
+
+    BatchProcessorSemaphore(ConfigT config,
+                          List<Operation<PayloadT>> batch,
+                          Semaphore batchProcessorsTracker,
+                          BatchTask<ConfigT, PayloadT, KeyT> batchTask, KeyT key,
+                          String batchManagerId,
+                          Profiler profiler) {
+        this.batchProcessorsTracker = batchProcessorsTracker;
+        this.config = config;
+        this.batch = batch;
+        this.batchTask = batchTask;
+        this.key = key;
+        this.profiler = profiler;
+
+        handleMetricIdentity = new Identity(
+                "Batch.processor.hndl",
+                BATCHING_MANAGER_ID_TAG_NAME, batchManagerId,
+                BATCHING_MANAGER_KEY_TAG_NAME, key.toString()
+        );
+
+        awaitExecution = profiler.profiledCall(new Identity(
+                "Batch.processor.await",
+                BATCHING_MANAGER_ID_TAG_NAME, batchManagerId,
+                BATCHING_MANAGER_KEY_TAG_NAME, key.toString()
+        )).start();
+    }
+
+    /**
+     * Process batch of operations
+     */
+    @Override
+    public void run() {
+        try {
+            batchProcessorsTracker.acquire();
+        } catch (InterruptedException exc) {
+            Thread.currentThread().interrupt();
+        } finally {
+            awaitExecution.stop();
+        }
+
+        try {
+            List<PayloadT> payloadBatch = batch.stream().map(Operation::getPayload).collect(Collectors.toList());
+            try (ProfiledCall profiledCall = profiler.profiledCall(handleMetricIdentity).start()) {
+                batchTask.process(config, payloadBatch, key);
+                profiledCall.stop(payloadBatch.size());
+            }
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+        } finally {
+            batchProcessorsTracker.release();
+        }
+    }
+}

--- a/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchProcessorSemaphore.java
+++ b/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchProcessorSemaphore.java
@@ -11,6 +11,13 @@ import java.util.stream.Collectors;
 import static ru.fix.stdlib.batching.BatchingManagerMetricsProvider.BATCHING_MANAGER_ID_TAG_NAME;
 import static ru.fix.stdlib.batching.BatchingManagerMetricsProvider.BATCHING_MANAGER_KEY_TAG_NAME;
 
+/**
+ * <b>For usage in jmh tests only!</b>
+ * @see BatchingManagerHighContentionJmh
+ * @param <ConfigT>
+ * @param <PayloadT>
+ * @param <KeyT>
+ */
 class BatchProcessorSemaphore<ConfigT, PayloadT, KeyT> implements Runnable {
 
     private final ConfigT config;

--- a/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerHighContentionJmh.java
+++ b/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerHighContentionJmh.java
@@ -8,6 +8,31 @@ import ru.fix.aggregating.profiler.NoopProfiler;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
+/**
+ * This test compares 2 cases of BatchProcessor threads tracking
+ * <dl>
+ *
+ * <dt><b>tracking via semaphore acquire/release</b></dt>
+ * <dd>{@link BatchingManagerThreadSemaphore}
+ * BatchingManagerThread tracks for free threads in batchProcessorPool using semaphore.
+ * Semaphore permits count equals to batchProcessorPool size. If all batchProcessorPool threads are busy,
+ * semaphore will have no permits and BatchingManagerThread will wait for some free thread in batchProcessorPool<p>
+ * This implementations depends on batchProcessorPool size. BatchProcessorPool size can be changed in runtime,
+ * but Semaphore permits <b>could not be changed in runtime</b> and such situation may case problems.<p>
+ * This implementation can be found in {@code src/jmh/java} and <b>it is not available in production code!</b>
+ * {@link BatchingManagerSemaphore},
+ * {@link BatchingManagerThreadSemaphore},
+ * {@link BatchProcessorSemaphore}
+ * </dd>
+ *
+ * <dt><b>tracking via object wait/notify</b></dt>
+ * <dd>{@link BatchingManagerThread}
+ * BatchingManagerThread tracks for free threads in batchProcessorPool using wait/notify synchronization.
+ * This implementations does not depend on batchProcessorPool size. Its performance practically the same as semaphore.
+ * </dd>
+ *
+ * </dl>
+ */
 @State(Scope.Benchmark)
 public class BatchingManagerHighContentionJmh {
 

--- a/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerHighContentionJmh.java
+++ b/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerHighContentionJmh.java
@@ -1,0 +1,81 @@
+package ru.fix.stdlib.batching;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import ru.fix.aggregating.profiler.NoopProfiler;
+
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+public class BatchingManagerHighContentionJmh {
+
+    private static final int TASKS = 100_000;
+    private static final int BATCH = 200;
+
+    private final BatchTask<Object, Object, String> task = (a, b, c) -> Thread.sleep(5);
+
+    @Benchmark
+    public void semaphoreTest() throws InterruptedException {
+        batchingManagersParallelStream().mapToObj(idx -> new BatchingManagerSemaphore<>(
+                new Object(),
+                task,
+                newBatchingParameters(),
+                "semaphore-" + idx,
+                new NoopProfiler())
+        ).forEach(manager -> new BatchingManagerEnqueuer().enqueueAllTasks(keyIdx -> {
+            try {
+                manager.enqueue("key_" + keyIdx, new Object());
+            } catch (InterruptedException ex) {
+                //nop
+            }
+        }));
+    }
+
+    @Benchmark
+    public void poolQueueSizeTest() throws InterruptedException {
+        batchingManagersParallelStream().mapToObj(idx -> new BatchingManager<>(
+                new Object(),
+                task,
+                newBatchingParameters(),
+                "pool-queue-size-" + idx,
+                new NoopProfiler())
+        ).forEach(manager -> new BatchingManagerEnqueuer().enqueueAllTasks(keyIdx -> {
+            try {
+                manager.enqueue("key_" + keyIdx, new Object());
+            } catch (InterruptedException ex) {
+                //nop
+            }
+        }));
+    }
+
+    private static IntStream batchingManagersParallelStream() {
+        return IntStream.range(1, 3).parallel();
+    }
+
+    private static BatchingParameters newBatchingParameters() {
+        return new BatchingParameters()
+                .setBatchTimeout(0)
+                .setBatchThreads(6)
+                .setBatchSize(BATCH)
+                .setMaxPendingOperations(1000_000)
+                .setBlockIfLimitExceeded(false);
+    }
+
+    private static class BatchingManagerEnqueuer {
+
+        public void enqueueAllTasks(IntConsumer taskEnqueuer) {
+            int keyIdx = 1;
+            for (int i = 0; i < TASKS; ++i) {
+                if (i % 5 == 0) {
+                    keyIdx = 1;
+                } else {
+                    keyIdx++;
+                }
+
+                taskEnqueuer.accept(keyIdx);
+            }
+        }
+    }
+}

--- a/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerSemaphore.java
+++ b/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerSemaphore.java
@@ -10,6 +10,13 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static java.lang.String.format;
 
+/**
+ * <b>For usage in jmh tests only!</b>
+ * @see BatchingManagerHighContentionJmh
+ * @param <ConfigT>
+ * @param <PayloadT>
+ * @param <KeyT>
+ */
 class BatchingManagerSemaphore<ConfigT, PayloadT, KeyT> implements AutoCloseable {
 
     /**

--- a/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerSemaphore.java
+++ b/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerSemaphore.java
@@ -1,0 +1,97 @@
+package ru.fix.stdlib.batching;
+
+import ru.fix.aggregating.profiler.Profiler;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static java.lang.String.format;
+
+class BatchingManagerSemaphore<ConfigT, PayloadT, KeyT> implements AutoCloseable {
+
+    /**
+     * Queues with operation, is limited by maxPendingOperations
+     */
+    private final Map<KeyT, Queue<Operation<PayloadT>>> pendingTableOperations = new ConcurrentHashMap<>();
+
+    /**
+     * Parameters for BatchProcessor
+     */
+    private final BatchingParameters batchingParameters;
+
+    /**
+     * Monitoring queue and create BatchProcessor for executed Row
+     */
+    private final BatchingManagerThreadSemaphore<ConfigT, PayloadT, KeyT> batchingManagerThread;
+
+    private final String batchManagerId;
+
+    private final Profiler profiler;
+
+    BatchingManagerSemaphore(ConfigT config,
+                           BatchTask<ConfigT, PayloadT, KeyT> batchTask,
+                           BatchingParameters batchingParameters,
+                           String batchManagerId,
+                           Profiler profiler) {
+        this.batchingParameters = batchingParameters;
+        this.batchManagerId = batchManagerId;
+        this.profiler = profiler;
+
+        profiler.attachIndicator(getIndicatorName(batchManagerId),
+                () -> pendingTableOperations.values().stream().mapToLong(Collection::size).sum()
+        );
+
+        this.batchingManagerThread = new BatchingManagerThreadSemaphore<>(config,
+                pendingTableOperations,
+                batchingParameters,
+                profiler,
+                batchManagerId,
+                batchTask);
+        this.batchingManagerThread.start();
+    }
+
+    private static String getIndicatorName(String batchManagerId) {
+        return "Batching.manager." + batchManagerId;
+    }
+
+    @Override
+    public void close() {
+        batchingManagerThread.shutdown();
+        profiler.detachIndicator(getIndicatorName(batchManagerId));
+    }
+
+    /**
+     * @param key     buffer key. {@link BatchingManager} will create separate batch queue for each key.
+     * @param payload data that will be collect in batches and passed to {@link  ru.fix.stdlib.batching.BatchTask}
+     * @throws MaxPendingOperationExceededException see {@link BatchingParameters#setMaxPendingOperations(int)}
+     * @throws InterruptedException                 if thread was interrupted while waiting in blocking mode
+     */
+    void enqueue(KeyT key, PayloadT payload) throws MaxPendingOperationExceededException, InterruptedException {
+        Queue<Operation<PayloadT>> operationQueue =
+                pendingTableOperations.computeIfAbsent(key, k -> new ConcurrentLinkedQueue<>());
+
+        Operation<PayloadT> operation = new Operation<>(payload, System.currentTimeMillis());
+        if (isBatchLimitReached(operationQueue)) {
+            if (batchingParameters.isBlockIfLimitExceeded()) {
+                while (isBatchLimitReached(operationQueue)) {
+                    synchronized (operationQueue) {
+                        operationQueue.wait();
+                    }
+                }
+            } else {
+                String message = format("Queue operations peaked, maxPendingOperations = %d",
+                        batchingParameters.getMaxPendingOperations());
+                throw new MaxPendingOperationExceededException(message);
+            }
+        }
+
+        operationQueue.add(operation);
+    }
+
+    private boolean isBatchLimitReached(Queue<Operation<PayloadT>> operationQueue) {
+        return operationQueue.size() >= batchingParameters.getMaxPendingOperations();
+    }
+}

--- a/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerThreadSemaphore.java
+++ b/jfix-stdlib-batching/src/jmh/java/ru/fix/stdlib/batching/BatchingManagerThreadSemaphore.java
@@ -15,6 +15,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * <b>For usage in jmh tests only!</b>
+ * @see BatchingManagerHighContentionJmh
+ * @param <ConfigT>
+ * @param <PayloadT>
+ * @param <KeyT>
+ */
 class BatchingManagerThreadSemaphore<ConfigT, PayloadT, KeyT> implements Runnable {
 
     private final AtomicBoolean isShutdown = new AtomicBoolean();

--- a/jfix-stdlib-batching/src/main/java/ru/fix/stdlib/batching/BatchProcessorsTracker.java
+++ b/jfix-stdlib-batching/src/main/java/ru/fix/stdlib/batching/BatchProcessorsTracker.java
@@ -1,0 +1,43 @@
+package ru.fix.stdlib.batching;
+
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.function.BooleanSupplier;
+
+class BatchProcessorsTracker {
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.of(100, ChronoUnit.MILLIS);
+
+    private final Object waitForBatchProcessorPoolLock = new Object();
+    private final Logger log;
+
+    BatchProcessorsTracker(Logger log) {
+        this.log = log;
+    }
+
+    boolean isBatchProcessorThreadAvailable(BooleanSupplier condition) throws InterruptedException {
+        return isBatchProcessorThreadAvailable(DEFAULT_TIMEOUT, condition);
+    }
+
+    boolean isBatchProcessorThreadAvailable(Duration timeout, BooleanSupplier condition) throws InterruptedException {
+        boolean isBatchProcessorThreadAvailable = condition.getAsBoolean();
+
+        if (isBatchProcessorThreadAvailable) {
+            log.trace("isBatchProcessorThreadAvailable");
+        } else {
+            synchronized (waitForBatchProcessorPoolLock) {
+                waitForBatchProcessorPoolLock.wait(timeout.toMillis());
+            }
+        }
+
+        return isBatchProcessorThreadAvailable;
+    }
+
+    void notifyAboutAvailableBatchProcessorThread() {
+        synchronized (waitForBatchProcessorPoolLock) {
+            waitForBatchProcessorPoolLock.notifyAll();
+        }
+    }
+}

--- a/jfix-stdlib-batching/src/main/java/ru/fix/stdlib/batching/BatchingManager.java
+++ b/jfix-stdlib-batching/src/main/java/ru/fix/stdlib/batching/BatchingManager.java
@@ -34,7 +34,7 @@ public class BatchingManager<ConfigT, PayloadT, KeyT> implements AutoCloseable {
     private final BatchingParameters batchingParameters;
 
     /**
-     * Monitoring queue and and create BatchProcessor for executed Row
+     * Monitoring queue and create BatchProcessor for executed Row
      */
     private final BatchingManagerThread<ConfigT, PayloadT, KeyT> batchingManagerThread;
 
@@ -112,12 +112,7 @@ public class BatchingManager<ConfigT, PayloadT, KeyT> implements AutoCloseable {
     }
 
     public BatchingManager<ConfigT, PayloadT, KeyT> setBatchThreads(int batchThreads) {
-        try {
-            batchingManagerThread.setThreadCount(batchThreads);
-        } catch (InterruptedException exc) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(exc);
-        }
+        batchingManagerThread.setThreadCount(batchThreads);
         return this;
     }
 

--- a/jfix-stdlib-batching/src/main/java/ru/fix/stdlib/batching/BatchingManagerMetricsProvider.java
+++ b/jfix-stdlib-batching/src/main/java/ru/fix/stdlib/batching/BatchingManagerMetricsProvider.java
@@ -38,11 +38,11 @@ public class BatchingManagerMetricsProvider {
         this.profiler = profiler;
     }
 
-    public Boolean profileBatchProcessorAwaitThread(Supplier<Boolean> awaiter) {
+    public boolean profileBatchProcessorAwaitThread(Supplier<Boolean> awaiter) {
         return profiler.profiledCall(batchProcessorThreadAwaitIdentity).profile(awaiter);
     }
 
-    public Boolean profileBatchManagerThreadAwaitOperation(Supplier<Boolean> awaiter) {
+    public boolean profileBatchManagerThreadAwaitOperation(Supplier<Boolean> awaiter) {
         return profiler.profiledCall(batchManagerOperationsAwaitIdentity).profile(awaiter);
     }
 

--- a/jfix-stdlib-batching/src/test/java/ru/fix/stdlib/batching/BatchingManagerHighContentionTest.java
+++ b/jfix-stdlib-batching/src/test/java/ru/fix/stdlib/batching/BatchingManagerHighContentionTest.java
@@ -1,5 +1,6 @@
 package ru.fix.stdlib.batching;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import ru.fix.aggregating.profiler.NoopProfiler;
@@ -23,6 +24,7 @@ class BatchingManagerHighContentionTest {
      *
      * @param mode Block if batch is full and new operation have come
      */
+    @Disabled("For manual running only! See javadoc for details.")
     @ParameterizedTest
     @EnumSource(value = Mode.class)
     void highContentionTest(Mode mode) {

--- a/jfix-stdlib-batching/src/test/java/ru/fix/stdlib/batching/BatchingManagerHighContentionTest.java
+++ b/jfix-stdlib-batching/src/test/java/ru/fix/stdlib/batching/BatchingManagerHighContentionTest.java
@@ -1,0 +1,72 @@
+package ru.fix.stdlib.batching;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import ru.fix.aggregating.profiler.NoopProfiler;
+
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BatchingManagerHighContentionTest {
+
+    private final static int TASK_COUNT = 200_000;
+    private final static int BATCH = 200;
+
+    /**
+     * This test creates 50 BatchingManagers working in parallel.<br>
+     * Every manager consumes and executes 200_000 tasks withing 20 batch threads.<br>
+     * There are 5 unique keys for all tasks.
+     * So every BatchingManagers works with 5 pending operations queues.
+     * <p>
+     * <b>Attention!</b>: log level trace strongly affects performance of this test!
+     *
+     * @param mode Block if batch is full and new operation have come
+     */
+    @ParameterizedTest
+    @EnumSource(value = Mode.class)
+    void highContentionTest(Mode mode) {
+
+        BatchTask<Object, Object, String> task = (a, b, c) -> {
+            synchronized (this) {
+                this.wait(10);
+            }
+        };
+
+        IntStream.range(1, 51).parallel().mapToObj(idx -> {
+            BatchingParameters parameters = new BatchingParameters()
+                    .setBatchTimeout(0)
+                    .setBatchSize(BATCH)
+                    .setBlockIfLimitExceeded(mode.blockIfLimitExceeded());
+
+            return new BatchingManager<>(new Object(), task, parameters, "high-contention-" + idx, new NoopProfiler());
+        }).forEach(manager -> {
+            int keyIdx = 1;
+            for (int i = 0; i < TASK_COUNT; ++i) {
+                if (i % 5 == 0) {
+                    keyIdx = 1;
+                } else {
+                    keyIdx++;
+                }
+
+                try {
+                    manager.enqueue("key_" + keyIdx, new Object());
+                } catch (InterruptedException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        });
+
+        assertTrue(true);
+    }
+
+
+    private enum Mode {
+        BLOCKING_MODE,
+        CONCURRENT_MODE;
+
+        boolean blockIfLimitExceeded() {
+            return BLOCKING_MODE == this;
+        }
+    }
+}

--- a/jfix-stdlib-batching/src/test/resources/log4j2-test.xml
+++ b/jfix-stdlib-batching/src/test/resources/log4j2-test.xml
@@ -10,7 +10,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="ru.fix" level="trace"/>
+        <Logger name="ru.fix" level="debug"/>
 
         <Root level="info">
             <AppenderRef ref="console"/>

--- a/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/threads/ProfiledThreadPoolExecutor.java
+++ b/jfix-stdlib-concurrency/src/main/java/ru/fix/stdlib/concurrency/threads/ProfiledThreadPoolExecutor.java
@@ -5,12 +5,75 @@ import ru.fix.aggregating.profiler.Profiler;
 import ru.fix.dynamic.property.api.DynamicProperty;
 import ru.fix.dynamic.property.api.PropertySubscription;
 
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * For complete documentation details see {@link ThreadPoolExecutor}
+ * <dl>
+ *
+ * <dt><b>Core and maximum pool sizes</b></dt>
+ * <dd>When a new task is submitted in method {@link #execute(Runnable)},
+ * if fewer than corePoolSize threads are running, a new thread is
+ * created to handle the request, even if other worker threads are
+ * idle.  Else if fewer than maximumPoolSize threads are running, a
+ * new thread will be created to handle the request only if the queue
+ * is full. By setting corePoolSize and maximumPoolSize the same, you
+ * create a fixed-size thread pool. By setting maximumPoolSize to an
+ * essentially unbounded value such as {@code Integer.MAX_VALUE}, you
+ * allow the pool to accommodate an arbitrary number of concurrent
+ * tasks. Most typically, core and maximum pool sizes are set only
+ * upon construction, but they may also be changed dynamically using
+ * {@link #setCorePoolSize} and {@link #setMaximumPoolSize}. </dd>
+ *
+ * <dt><b>On-demand construction</b></dt>
+ * <dd>By default, even core threads are initially created and
+ * started only when new tasks arrive, but this can be overridden
+ * dynamically using method {@link #prestartCoreThread} or {@link
+ * #prestartAllCoreThreads}.  You probably want to prestart threads if
+ * you construct the pool with a non-empty queue. </dd>
+ *
+ * <dt><b>Keep-alive times</b></dt>
+ * <dd>If the pool currently has more than corePoolSize threads,
+ * excess threads will be terminated if they have been idle for more
+ * than the keepAliveTime (see {@link #getKeepAliveTime(TimeUnit)}).
+ * This provides a means of reducing resource consumption when the
+ * pool is not being actively used. If the pool becomes more active
+ * later, new threads will be constructed. This parameter can also be
+ * changed dynamically using method {@link #setKeepAliveTime(long,
+ * TimeUnit)}.  Using a value of {@code Long.MAX_VALUE} {@link
+ * TimeUnit#NANOSECONDS} effectively disables idle threads from ever
+ * terminating prior to shut down. By default, the keep-alive policy
+ * applies only when there are more than corePoolSize threads, but
+ * method {@link #allowCoreThreadTimeOut(boolean)} can be used to
+ * apply this time-out policy to core threads as well, so long as the
+ * keepAliveTime value is non-zero. </dd>
+ *
+ * <dt><b>Queuing</b></dt>
+ * <dd>Any {@link BlockingQueue} may be used to transfer and hold
+ * submitted tasks.  The use of this queue interacts with pool sizing:
+ * <ul>
+ * <li>If fewer than corePoolSize threads are running, the Executor
+ * always prefers adding a new thread
+ * rather than queuing.
+ * <li>If corePoolSize or more threads are running, the Executor
+ * always prefers queuing a request rather than adding a new
+ * thread.
+ * <li>If a request cannot be queued, a new thread is created unless
+ * this would exceed maximumPoolSize, in which case, the task will be
+ * rejected.
+ * </ul>
+ * </dd>
+ *
+ * </dl>
+ *
+ * Developers are urged to use the more convenient
+ * {@link Executors} factory methods {@link Executors#newCachedThreadPool}
+ * (unbounded thread pool, with automatic thread reclamation),
+ * {@link Executors#newFixedThreadPool} (fixed size thread pool)
+ * and {@link Executors#newSingleThreadExecutor} (single background thread),
+ * that preconfigure settings for the most common usage scenarios.
+ */
 public class ProfiledThreadPoolExecutor extends ThreadPoolExecutor {
 
     private static final long THREAD_IDLE_TIMEOUT_BEFORE_TERMINATION_SEC = 60;

--- a/jfix-stdlib-id-generator-jmh/build.gradle.kts
+++ b/jfix-stdlib-id-generator-jmh/build.gradle.kts
@@ -1,15 +1,15 @@
 plugins {
     java
     kotlin("jvm")
-    id("me.champeau.gradle.jmh")
+    id(Libs.jmh_gradle_plugin) apply true
 }
 
 
-jmh{
-    warmupIterations = 2
-    fork = 2
-    threads = 8
-    duplicateClassesStrategy  = DuplicatesStrategy.WARN
+jmh {
+    warmupIterations.set(2)
+    fork.set(2)
+    threads.set(8)
+    duplicateClassesStrategy.set(DuplicatesStrategy.WARN)
 }
 
 
@@ -23,5 +23,3 @@ dependencies {
     runtimeOnly(Libs.jmh_generator_bytecode)
     implementation(Libs.jmh_generator_ann)
 }
-
-


### PR DESCRIPTION
Semaphore in BatchingManagerThread was replaced by BatchProcessorsTracker.

BatchProcessorsTracker does not depend on batchProcessorPool size.